### PR TITLE
Fix invalid login using redfish url.

### DIFF
--- a/redfish/main.py
+++ b/redfish/main.py
@@ -127,7 +127,7 @@ from builtins import object
 
 
 import json
-from urllib.parse import urlparse
+from urllib.parse import urlparse, urljoin
 import requests
 from . import config
 from . import types
@@ -289,7 +289,7 @@ class RedfishConnection(object):
         # Handle login with redfish 1.00, url must be :
         # /rest/v1/SessionService/Sessions as specified by the specification
         if float(mapping.redfish_version) >= 1.00:
-            url += '/Sessions'
+            url = urljoin(url, "Sessions")
 
         # Craft request body and header
         requestBody = {"UserName": self.connection_parameters.user_name  , "Password": self.connection_parameters.password}


### PR DESCRIPTION
Hi Bruno,

This should fix the issue you have seen Friday.
Please let me know if it works on your side.

By the way I'm also interested in the following case.
Try to use the root url of the rilo (login screen) sending html. Can you please check if the error is handled correctly.
