### PR TITLE
Fix for Moonshot platform

### DIFF
--- a/redfish/types.py
+++ b/redfish/types.py
@@ -66,6 +66,7 @@ class Base(object):
             links = getattr(self.data, mapping.redfish_mapper.map_links())
             if link_type in links:
                 return urljoin(self.url, links[link_type][mapping.redfish_mapper.map_links_ref()])
+            raise AttributeError
         else:
             links = getattr(self.data, link_type)
             link = getattr(links, mapping.redfish_mapper.map_links_ref())


### PR DESCRIPTION
- Fix to not crash although Moonshot Redfish is 0.95 even with firmware
  1.41
