### PR TITLE
Fix rpm build with pb for CentOS7

### DIFF
--- a/pbconf/pbfilter/all.pbf
+++ b/pbconf/pbfilter/all.pbf
@@ -70,3 +70,5 @@ filter PBLOG = yes
 filter PBCONFFILE = /etc/redfish-client.conf
 filter PBTEMPLATEPATH = /usr/share/redfish-client/templates
 filter PBPYTHON3FILTER = perl -pi -e "s|configparser>=3.3.0; python_version < '3'|configparser>=3.3.0|" requirements.txt
+# By default build for python3
+filter PBWITHPY3 = 1

--- a/pbconf/pbfilter/centos.pbf
+++ b/pbconf/pbfilter/centos.pbf
@@ -1,0 +1,29 @@
+#
+# $Id$
+#
+# Filter for rpm build
+#
+
+# PBGRP is replaced by the RPM group of apps
+# Cf: http://fedoraproject.org/wiki/RPMGroups
+#filter PBGRP = Applications/Archiving
+
+# PBLIC is replaced by the license of the application
+# Cf: http://fedoraproject.org/wiki/Licensing
+#filter PBLIC = GPLv2+
+
+# PBDEP is replaced by the list of dependencies
+#filter PBDEP =
+
+# PBBDEP is replaced by the list of build dependencies
+#filter PBBDEP =
+
+# PBSUF is replaced by the package suffix ($pb->{'suf'} in code)
+filter PBSUF = %{dist}
+
+# PBOBS is replaced by the Obsolete line
+#filter PBOBS =
+
+filter PB2PYTHON2BDEP = texlive-framed
+filter PB2PYTHON3BDEP = 
+filter PBWITHPY3 = 0

--- a/pbconf/pbfilter/rpm.pbf
+++ b/pbconf/pbfilter/rpm.pbf
@@ -14,7 +14,7 @@ filter PBLIC = ASL 2.0
 #filter PBDEP =
 
 # PBBDEP is replaced by the list of build dependencies
-filter PBPYTHON2BDEP = python-devel,python-setuptools >= 18,python-sphinx >= 1.2.3,python-future >= 0.15.2,python-docopt >= 0.6.2,python-requests >= 2.9.1,python-simplejson >= 3.8.1,python-configparser >= 3.3.0,texlive,python-sphinx_rtd_theme
+filter PBPYTHON2BDEP = make,python-devel,python-setuptools >= 18,python-sphinx >= 1.2.3,python-future >= 0.15.2,python-docopt >= 0.6.2,python-requests >= 2.9.1,python-simplejson >= 3.8.1,python-configparser >= 3.3.0,texlive,python-sphinx_rtd_theme
 filter PBPYTHON2DEP = python-docopt >= 0.6.2,python-tortilla >= 0.4.1,python-jinja2 >= 2.7.3,python-simplejson >= 3.8.1,python-requests >= 2.9.1,python-configparser >= 3.3.0
 filter PBPYTHON3BDEP = python3-devel,python3-setuptools >= 18,python3-sphinx >= 1.2.3,python3-future >= 0.15.2,python3-docopt >= 0.6.2,python3-requests >= 2.9.1,python3-simplejson >= 3.8.1,texlive,python3-sphinx_rtd_theme
 filter PBPYTHON3DEP = python3-docopt >= 0.6.2,python3-tortilla >= 0.4.1,python3-jinja2 >= 2.7.3,python3-simplejson >= 3.8.1,python3-requests >= 2.9.1

--- a/pbconf/pbfilter/rpm.pbf
+++ b/pbconf/pbfilter/rpm.pbf
@@ -15,7 +15,7 @@ filter PBLIC = ASL 2.0
 
 # PBBDEP is replaced by the list of build dependencies
 filter PBPYTHON2BDEP = make,python-devel,python-setuptools >= 18,python-sphinx >= 1.2.3,python-future >= 0.15.2,python-docopt >= 0.6.2,python-requests >= 2.9.1,python-simplejson >= 3.8.1,python-configparser >= 3.3.0,texlive,python-sphinx_rtd_theme
-filter PBPYTHON2DEP = python-docopt >= 0.6.2,python-tortilla >= 0.4.1,python-jinja2 >= 2.7.3,python-simplejson >= 3.8.1,python-requests >= 2.9.1,python-configparser >= 3.3.0
+filter PBPYTHON2DEP = python-docopt >= 0.6.2,python-tortilla >= 0.4.1,python-jinja2 >= 2.7.3,python-simplejson >= 3.8.1,python-requests >= 2.9.1,python-configparser >= 3.3.0,python-future >= 0.15.2
 filter PBPYTHON3BDEP = python3-devel,python3-setuptools >= 18,python3-sphinx >= 1.2.3,python3-future >= 0.15.2,python3-docopt >= 0.6.2,python3-requests >= 2.9.1,python3-simplejson >= 3.8.1,texlive,python3-sphinx_rtd_theme
 filter PBPYTHON3DEP = python3-docopt >= 0.6.2,python3-tortilla >= 0.4.1,python3-jinja2 >= 2.7.3,python3-simplejson >= 3.8.1,python3-requests >= 2.9.1
 filter PBPYTHON3PKG = python3-redfish

--- a/pbconf/python-redfish.pb
+++ b/pbconf/python-redfish.pb
@@ -55,7 +55,7 @@ sshport python-redfish = 22
 # a .vmtype extension will be added to the resulting string
 # a QEMU rhel-3-i286 here means that the VM will be named rhel-3-i386.qemu
 #
-vmlist python-redfish = rhel-6-i386,opensuse-12.3-i386,sles-11-i386,gentoo-nover-i386,debian-8-i386,ubuntu-14.04-i386,ubuntu-15.10-i386,mageia-4-i386,mageia-5-i386,mageia-4-x86_64,mageia-5-x86_64,fedora-22-x86_64,fedora-23-x86_64,rhel-6-x86_64,rhel-7-x86_64,opensuse-12.3-i386,sles-10-x86_64,sles-11-x86_64,sles-12-x86_64,gentoo-nover-x86_64,debian-8-x86_64,ubuntu-14.04-x86_64,ubuntu-15.10-x86_64
+vmlist python-redfish = opensuse-12.3-i386,debian-8-i386,ubuntu-16.04-i386,mageia-5-i386,mageia-5-x86_64,fedora-23-x86_64,rhel-7-x86_64,opensuse-12.3-x86_64,sles-12-x86_64,debian-8-x86_64,ubuntu-16.04-x86_64
 
 #
 # Valid values for vmtype are
@@ -99,7 +99,7 @@ vetype python-redfish = docker
 #
 # Global version/tag for the project
 #
-projver python-redfish = 0.3
+projver python-redfish = 0.4
 projtag python-redfish = 1
 
 # Hash of valid version names
@@ -110,9 +110,9 @@ projtag python-redfish = 1
 #version python-redfish = devel,stable
 
 # Is it a test version or a production version
-#testver python-redfish = true
+testver python-redfish = true
 # Which upper target dir for delivery
-delivery python-redfish =
+delivery python-redfish = test
 
 # Additional repository to add at build time
 # addrepo centos-5-x86_64 = http://packages.sw.be/rpmforge-release/rpmforge-release-0.3.6-1.el5.rf.x86_64.rpm,ftp://ftp.project-builder.org/centos/5/pb.repo

--- a/pbconf/python-redfish/rpm/python-redfish.spec
+++ b/pbconf/python-redfish/rpm/python-redfish.spec
@@ -1,6 +1,8 @@
 #
 # $Id$
 #
+%global with_python3 PBWITHPY3
+
 
 Name:           PBREALPKG
 Version:        PBVER
@@ -19,19 +21,21 @@ BuildRequires:  PBPYTHON2BDEP, PB2PYTHON2BDEP
 PBDESC
 Python2 version.
 
+%if %{?with_python3}
 %package -n PBPYTHON3PKG
 Summary: %{summary} / Python 3 library
-BuildRequires:  PBPYTHON3BDEP, PB2PYTHON3BDEP
-Requires:       PBPYTHON3DEP
-
-%package -n PBREALPKG-doc
-Summary: %{summary} / Documentation
 BuildRequires:  PBPYTHON3BDEP, PB2PYTHON3BDEP
 Requires:       PBPYTHON3DEP
 
 %description -n PBPYTHON3PKG
 PBDESC
 Python3 version.
+%endif # if with_python3
+
+%package -n PBREALPKG-doc
+Summary: %{summary} / Documentation
+BuildRequires:  PBPYTHON2BDEP, PB2PYTHON2BDEP
+Requires:       PBPYTHON2DEP
 
 %description -n PBREALPKG-doc
 PBDESC
@@ -40,18 +44,22 @@ Documentation
 %prep
 %setup -q
 # Fix for now as long as setuptools isn't more recent in distributions
+%if %{?with_python3}
 PBPYTHON3FILTER
 cp -a . %{py3dir}
 # python3 doesn't provide configparser at all
 (cd %{py3dir} ; perl -pi -e "s|configparser>=3.3.0||" requirements.txt)
+%endif # if with_python3
 
 %build
+%if %{?with_python3}
 pushd %{py3dir}
 %{__python3} setup.py build
 # Build minimal documentation
 cd doc
 make man
 popd
+%endif # if with_python3
 
 %{__python} setup.py build
 # Build minimal documentation
@@ -70,9 +78,11 @@ for i in `ls %{buildroot}/%{_mandir}/man1/*-py2.1*`; do
 	cp -a $i $j
 done
 
+%if %{?with_python3}
 pushd %{py3dir} 
 ./install.sh %{__python3} %{buildroot} %{python3_sitelib} %{_prefix} PBPYTHON3PKG
 popd
+%endif # if with_python3
 
 %files
 %doc README.rst examples/[a-z]*.py LICENSE
@@ -89,6 +99,7 @@ popd
 %{_mandir}/man1/PBREALPKG.1*
 %{_mandir}/man1/*-py2.1*
 
+%if %{?with_python3}
 %files -n PBPYTHON3PKG
 %doc README.rst examples/[a-z]*.py LICENSE AUTHORS ChangeLog
 %dir %{python3_sitelib}/redfish
@@ -96,6 +107,7 @@ popd
 %{python3_sitelib}/redfish/__pycache__/*.py*
 %{python3_sitelib}/python_redfish*
 %{_mandir}/man1/*-py3.1*
+%endif # if with_python3
 
 %files -n PBREALPKG-doc
 %{_docdir}/PBREALPKG/manual/html/_static/*


### PR DESCRIPTION
- Adds a macro to build for python3 (not activated for CentOS 7)
- Fix dependency list for CentoS7
- Limit VM list to reasonable distros
- This is again a test version.
- Build Test remains to be done for Fedora and Mageia
