### PR TITLE
Fix mockup invalid json

### DIFF
--- a/dmtf/Dockerfile
+++ b/dmtf/Dockerfile
@@ -5,9 +5,10 @@ MAINTAINER bruno.cornec@hpe.com
 ENV DEBIAN_FRONTEND noninterative
 # Install deps for Redfish mockup
 RUN apt-get update
-RUN apt-get -y install apache2 unzip sed
+RUN apt-get -y install apache2 unzip sed patch vim
 EXPOSE 80
 COPY redfish-setup.sh /tmp/redfish-setup.sh
 COPY DSP2043_0.99.0a.zip /tmp/DSP2043_0.99.0a.zip
-RUN chmod 755 /tmp/redfish-setup.sh 
+COPY fix_manager_ei.patch /tmp/fix_manager_ei.patch
+RUN chmod 755 /tmp/redfish-setup.sh
 CMD /tmp/redfish-setup.sh

--- a/dmtf/fix_manager_ei.patch
+++ b/dmtf/fix_manager_ei.patch
@@ -1,0 +1,11 @@
+--- /var/www/html/redfish/Managers/1/EthernetInterfaces/1/index.html	2016-05-28 13:09:32.028645250 +0000
++++ /var/www/html/redfish/Managers/1/EthernetInterfaces/1/index.html.patched	2016-05-28 13:21:19.826186341 +0000
+@@ -67,7 +67,7 @@
+         ]
+     },
+     "@Redfish.Settings": {
+-        "@odata.type": "#Settings.1.0.0.Settings"
++        "@odata.type": "#Settings.1.0.0.Settings",
+         "SettingsObject": {
+             "@odata.id": "/redfish/v1/Managers/1/EthernetInterfaces/1/SD"
+         },

--- a/dmtf/redfish-setup.sh
+++ b/dmtf/redfish-setup.sh
@@ -16,6 +16,7 @@ trap stop_apache HUP INT QUIT KILL TERM
 
 
 # Main
+[ -f /run/apache2/apache2.pid ] &&  rm -rf /run/apache2/apache2.pid # Avoid pb to restart container if brutally killed
 cd /var/www/html
 unzip -q -o /tmp/DSP2043_0.99.0a.zip
 chmod 755 DSP2043_0.99.0a
@@ -23,6 +24,9 @@ ln -sf DSP2043_0.99.0a redfish
 cd redfish
 ln -sf . v1
 cd ..
+# Patch simulator to fix incorrect json
+cd /
+patch -p0 < /tmp/fix_manager_ei.patch
 ip a
 #sed -i -e 's/Listen 80/Listen 8000/' /etc/apache2/ports.conf
 start_apache


### PR DESCRIPTION
Fix mockup invalid json into http://localhost:8000/redfish/v1/Manager…
- Update container creation process to patch the mockup.
- Also remove apache pid file if present. Happens if container is
  brutally killed.
